### PR TITLE
Build on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 .*.sw*
+*.exe

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .*.sw*
 *.exe
+*.obj

--- a/code/make.bat
+++ b/code/make.bat
@@ -1,0 +1,6 @@
+rem     Uses cl.exe to create plain-knit.exe
+rem     Ensure that cl.exe is on your PATH 
+rem     (e.g., by using a Visual Studio Developer Command Prompt)
+
+cl.exe /O2 /Wall /Fe"plain-knit.exe" plain-knit.c
+del plain-knit.obj

--- a/code/plain-knit.c
+++ b/code/plain-knit.c
@@ -1,6 +1,10 @@
 #include <stdio.h>
 #include <math.h>
 
+#if !defined(M_PI)
+#define M_PI 3.14159265359
+#endif
+
 struct Vector3
 {
    double x;


### PR DESCRIPTION
This PR establishes Windows compatibility of the source code.
It also adds a `make.bat` file to build `plain-knit.exe` from `plain-knit.c`.